### PR TITLE
Adding support for php-gd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM php:7.3-apache
 ENV APACHE_DOCUMENT_ROOT /var/www/illarion/website
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y ssl-cert libpq-dev && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y ssl-cert libpq-dev libpng-dev && \
     rm -r /var/lib/apt/lists/* && \
     docker-php-ext-install -j$(nproc) pgsql && \
+    docker-php-ext-install -j$(nproc) gd && \
     sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf && \
     sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf && \
     a2enmod ssl && \


### PR DESCRIPTION
The gd extension for PHP is required to test the graphics generation of the
website.

An example of the statistics page of the website.